### PR TITLE
enh: 모바일 대응 더 넓게 브레이크 포인트 변경

### DIFF
--- a/src/components/shared/sprinkles.css.ts
+++ b/src/components/shared/sprinkles.css.ts
@@ -3,8 +3,8 @@ import { defineProperties, createSprinkles } from '@vanilla-extract/sprinkles'
 import { theme } from './theme.css'
 
 export const mediaQuery = {
-  mobile: 'screen and (max-width: 375px)',
-  tablet: 'screen and (min-width: 376px)',
+  mobile: 'screen and (max-width: 576px)',
+  tablet: 'screen and (min-width: 577px)',
   desktop: 'screen and (min-width: 769px)',
 }
 


### PR DESCRIPTION
## 변경 사항
- mobile breakpoint max-width 375px -> 576px
- tablet breakpoint min-width 577px